### PR TITLE
added a way to sanitise headers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<groupId>com.tapstream</groupId>
 	<artifactId>rollbar-logback</artifactId>
 	<packaging>jar</packaging>
-	<version>0.1.1</version>
+	<version>0.1.2-SNAPSHOT</version>
 
 	<name>${project.groupId}:${project.artifactId}</name>
 	<description>A Rollbar logback appender that includes out of the box support for servlets</description>

--- a/src/main/java/com/tapstream/rollbar/RollbarFilter.java
+++ b/src/main/java/com/tapstream/rollbar/RollbarFilter.java
@@ -4,8 +4,7 @@ import com.tapstream.rollbar.sanitize.HeaderSanitizer;
 import com.tapstream.rollbar.sanitize.NoOpHeaderSanitizer;
 import com.tapstream.rollbar.sanitize.SanitizedHttpRequest;
 
-import java.io.IOException;
-import java.util.Enumeration;
+import org.slf4j.MDC;
 
 import javax.servlet.Filter;
 import javax.servlet.FilterChain;
@@ -15,7 +14,9 @@ import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletRequest;
 
-import org.slf4j.MDC;
+import java.io.IOException;
+import java.util.Enumeration;
+import java.util.Objects;
 
 
 public class RollbarFilter implements Filter {
@@ -32,13 +33,12 @@ public class RollbarFilter implements Filter {
     private final HeaderSanitizer headerSanitizer;
 
     public RollbarFilter() {
-        this.headerSanitizer = new NoOpHeaderSanitizer();
+        this(new NoOpHeaderSanitizer());
     }
 
     public RollbarFilter(HeaderSanitizer headerSanitizer) {
-        if (headerSanitizer == null) {
-            throw new IllegalArgumentException("HeaderSanitizer must be provided");
-        }
+        Objects.requireNonNull(headerSanitizer);
+        
         this.headerSanitizer = headerSanitizer;
     }
     
@@ -69,9 +69,9 @@ public class RollbarFilter implements Filter {
     }
 
     private void insertIntoMDCHttp(HttpServletRequest httpRequest) {
-        StringBuffer requestUrl = httpRequest.getRequestURL();
-        if (requestUrl != null){
-            MDC.put(REQUEST_URL, requestUrl.toString());
+        String requestUrl = Objects.toString(httpRequest.getRequestURL(), null);
+        if (requestUrl != null) {
+            MDC.put(REQUEST_URL, requestUrl);
         }
         MDC.put(REQUEST_QS, httpRequest.getQueryString());
         MDC.put(REQUEST_METHOD, httpRequest.getMethod());

--- a/src/main/java/com/tapstream/rollbar/sanitize/HeaderSanitizer.java
+++ b/src/main/java/com/tapstream/rollbar/sanitize/HeaderSanitizer.java
@@ -1,0 +1,11 @@
+package com.tapstream.rollbar.sanitize;
+
+public interface HeaderSanitizer {
+    /**
+     * Returns header value with sensitive information removed.
+     * @param headerName
+     * @param headerValue
+     * @return header value without sensitive information. null if header should be omitted.
+     */
+    String sanitize(String headerName, String headerValue);
+}

--- a/src/main/java/com/tapstream/rollbar/sanitize/NoOpHeaderSanitizer.java
+++ b/src/main/java/com/tapstream/rollbar/sanitize/NoOpHeaderSanitizer.java
@@ -1,0 +1,11 @@
+package com.tapstream.rollbar.sanitize;
+
+
+public class NoOpHeaderSanitizer implements HeaderSanitizer {
+
+    @Override
+    public String sanitize(String headerName, String headerValue) {
+        return headerValue;
+    }
+
+}

--- a/src/main/java/com/tapstream/rollbar/sanitize/SanitizedHttpRequest.java
+++ b/src/main/java/com/tapstream/rollbar/sanitize/SanitizedHttpRequest.java
@@ -11,10 +11,10 @@ import java.util.Map;
 
 
 /**
- * Provides HttpServletRequest with sensitive information removed or obfuscated.
+ * Provides {@link HttpServletRequest} with sensitive information removed or obfuscated.
  */
 public class SanitizedHttpRequest extends HttpServletRequestWrapper {
-    private HeaderSanitizer headerSanitizer;
+    private final HeaderSanitizer headerSanitizer;
 
     private final Map<String, String> sanitizedHeaders;
 
@@ -24,7 +24,7 @@ public class SanitizedHttpRequest extends HttpServletRequestWrapper {
         super(request);
         this.originalRequest = request;
         this.headerSanitizer = headerSanitizer;
-        sanitizedHeaders = sanitizeHeaders();
+        this.sanitizedHeaders = sanitizeHeaders();
     }
 
     @Override
@@ -37,8 +37,8 @@ public class SanitizedHttpRequest extends HttpServletRequestWrapper {
         return Collections.enumeration(sanitizedHeaders.keySet());
     }
 
-    private HashMap<String, String> sanitizeHeaders() {
-        HashMap<String, String> newHeaders = new HashMap<String, String>();
+    private Map<String, String> sanitizeHeaders() {
+        Map<String, String> newHeaders = new HashMap<String, String>();
         for (Enumeration<String> headerNames = originalRequest.getHeaderNames(); headerNames.hasMoreElements();) {
             String name = headerNames.nextElement();
             sanitizeHeader(name, originalRequest.getHeader(name), newHeaders);
@@ -46,7 +46,7 @@ public class SanitizedHttpRequest extends HttpServletRequestWrapper {
         return newHeaders;
     }
 
-    private void sanitizeHeader(String name, String originalValue, HashMap<String, String> newHeaders) {
+    private void sanitizeHeader(String name, String originalValue, Map<String, String> newHeaders) {
         String value = headerSanitizer.sanitize(name, originalValue);
         if (value != null) {
             newHeaders.put(name, value);

--- a/src/main/java/com/tapstream/rollbar/sanitize/SanitizedHttpRequest.java
+++ b/src/main/java/com/tapstream/rollbar/sanitize/SanitizedHttpRequest.java
@@ -1,0 +1,75 @@
+package com.tapstream.rollbar.sanitize;
+
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletRequestWrapper;
+
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.Map;
+
+
+/**
+ * Provides HttpServletRequest with sensitive information removed or obfuscated.
+ */
+public class SanitizedHttpRequest extends HttpServletRequestWrapper {
+    private HeaderSanitizer headerSanitizer;
+
+    private final Map<String, String> sanitizedHeaders;
+
+    private final HttpServletRequest originalRequest;
+
+    public SanitizedHttpRequest(HttpServletRequest request, HeaderSanitizer headerSanitizer) {
+        super(request);
+        this.originalRequest = request;
+        this.headerSanitizer = headerSanitizer;
+        sanitizedHeaders = sanitizeHeaders();
+    }
+
+    @Override
+    public String getHeader(String name) {
+        return sanitizedHeaders.get(name);
+    }
+
+    @Override
+    public Enumeration<String> getHeaderNames() {
+        return Collections.enumeration(sanitizedHeaders.keySet());
+    }
+
+    private HashMap<String, String> sanitizeHeaders() {
+        HashMap<String, String> newHeaders = new HashMap<String, String>();
+        for (Enumeration<String> headerNames = originalRequest.getHeaderNames(); headerNames.hasMoreElements();) {
+            String name = headerNames.nextElement();
+            sanitizeHeader(name, originalRequest.getHeader(name), newHeaders);
+        }
+        return newHeaders;
+    }
+
+    private void sanitizeHeader(String name, String originalValue, HashMap<String, String> newHeaders) {
+        String value = headerSanitizer.sanitize(name, originalValue);
+        if (value != null) {
+            newHeaders.put(name, value);
+        }
+    }
+
+    @Override
+    public Cookie[] getCookies() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public long getDateHeader(String name) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Enumeration<String> getHeaders(String name) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int getIntHeader(String name) {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/src/test/java/com/tapstream/rollbar/TestRollbarFilter.java
+++ b/src/test/java/com/tapstream/rollbar/TestRollbarFilter.java
@@ -1,40 +1,63 @@
 package com.tapstream.rollbar;
 
-import static org.hamcrest.MatcherAssert.*;
-import static org.hamcrest.Matchers.*;
-import static org.mockito.Matchers.*;
-import static org.mockito.Mockito.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.equalToIgnoringCase;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertFalse;
+import static org.mockito.Matchers.argThat;
+import static org.mockito.Mockito.when;
 
-import java.util.HashMap;
-import java.util.Hashtable;
-import java.util.Map;
-
-import javax.servlet.FilterConfig;
-import javax.servlet.http.HttpServletRequest;
+import com.tapstream.rollbar.sanitize.HeaderSanitizer;
 
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
 import org.slf4j.MDC;
 
+import javax.servlet.FilterConfig;
+import javax.servlet.http.HttpServletRequest;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Hashtable;
+import java.util.List;
+import java.util.Map;
+
+@RunWith(MockitoJUnitRunner.class)
 public class TestRollbarFilter {
     
-    RollbarFilter filter;
+    @Mock
+    private HttpServletRequest request;
+    @Mock
+    private FilterConfig filterConfig;
     
     @Before
-    public void setup() throws Exception {
-        filter = new RollbarFilter();
-        filter.init(mock(FilterConfig.class));
-    }
-    
     @After
-    public void teardown() throws Exception {
-        filter.destroy();
+    public void before() {
+        MDC.clear();
     }
     
     @Test
+    public void initSucceeds() throws Exception {
+        new RollbarFilter().init(filterConfig);
+        
+        // expecting no exception
+    }
+    @Test
+    public void destroySucceeds() {
+        new RollbarFilter().destroy();
+        
+        // expecting no exception 
+    }
+    @Test
     public void testFilter() throws Exception {
-        HttpServletRequest request = mock(HttpServletRequest.class);
+        RollbarFilter filter = new RollbarFilter();
         
         final String remoteAddr = "1.2.3.4";
         final String qs = "?qs=test";
@@ -47,6 +70,7 @@ public class TestRollbarFilter {
         
         Hashtable<String, String> headers = new Hashtable<>();
         headers.put(headerName, headerValue);
+        headers.put("User-Agent", ua);
         
         Hashtable<String, String> params = new Hashtable<>();
         params.put(paramName, paramValue);
@@ -63,6 +87,7 @@ public class TestRollbarFilter {
         filter.insertIntoMDC(request);
         
         Map<String, String> actual = MDC.getCopyOfContextMap();
+        @SuppressWarnings("serial")
         Map<String, String> expected = new HashMap<String, String>(){{
             put(RollbarFilter.REQUEST_REMOTE_ADDR, remoteAddr);
             put(RollbarFilter.REQUEST_QS, qs);
@@ -71,12 +96,54 @@ public class TestRollbarFilter {
         }};
         
         expected.put(RollbarFilter.REQUEST_HEADER_PREFIX + headerName, headerValue);
+        expected.put(RollbarFilter.REQUEST_HEADER_PREFIX + "User-Agent", ua);
         expected.put(RollbarFilter.REQUEST_PARAM_PREFIX + paramName, paramValue);
         
         assertThat(actual, is(equalTo(expected)));
         
         filter.clearMDC();
         assertThat(MDC.getCopyOfContextMap(), is(nullValue()));
+    }
+    
+    @Test
+    public void headerValuesAreSanitized() {
+        //given
+        List<String> headerNames = new ArrayList<String>();
+        headerNames.add("secureHeader");
+        headerNames.add("otherHeader");
+        headerNames.add("secureHeaderToRemove");
+        when(request.getHeaderNames()).thenReturn(Collections.enumeration(headerNames));
+        when(request.getHeader("secureHeader")).thenReturn("secret");
+        when(request.getHeader("otherHeader")).thenReturn("otherValue");
+        when(request.getHeader("secureHeaderToRemove")).thenReturn("secret2");
+        when(request.getParameterNames()).thenReturn(Collections.enumeration(Collections.<String>emptyList()));
+        
+        HeaderSanitizer headerSanitizer = new HeaderSanitizer() {
+            @Override
+            public String sanitize(String headerName, String headerValue) {
+                if(headerName.equals("secureHeader")) {
+                    return "XXX";
+                }else if(headerName.equals("otherHeader")) {
+                    return headerValue;
+                }else if(headerName.equals("secureHeaderToRemove")) {
+                    return null;
+                }else {
+                    throw new IllegalArgumentException();
+                }
+            }
+        };
+        
+        // when
+        RollbarFilter filter = new RollbarFilter(headerSanitizer);
+        filter.insertIntoMDC(request);
+        
+        // then
+        Map<String, String> actual = MDC.getCopyOfContextMap();
+        System.out.println(actual.toString());
+        assertThat(actual.get("request.header.secureHeader"), is(equalTo("XXX")));
+        assertThat(actual.get("request.header.otherHeader"), is(equalTo("otherValue")));
+        assertFalse(actual.containsKey("request.header.secureHeaderToRemove"));
+        
     }
     
 }

--- a/src/test/java/com/tapstream/rollbar/TestRollbarFilter.java
+++ b/src/test/java/com/tapstream/rollbar/TestRollbarFilter.java
@@ -22,11 +22,10 @@ import org.slf4j.MDC;
 import javax.servlet.FilterConfig;
 import javax.servlet.http.HttpServletRequest;
 
-import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Hashtable;
-import java.util.List;
 import java.util.Map;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -68,9 +67,10 @@ public class TestRollbarFilter {
         final String paramName = "paramName";
         final String paramValue = "paramValue";
         
-        Hashtable<String, String> headers = new Hashtable<>();
-        headers.put(headerName, headerValue);
-        headers.put("User-Agent", ua);
+        Hashtable<String, String> headers = new Hashtable<String, String>() {{
+            put(headerName, headerValue);
+            put("User-Agent", ua);
+        }};
         
         Hashtable<String, String> params = new Hashtable<>();
         params.put(paramName, paramValue);
@@ -108,11 +108,8 @@ public class TestRollbarFilter {
     @Test
     public void headerValuesAreSanitized() {
         //given
-        List<String> headerNames = new ArrayList<String>();
-        headerNames.add("secureHeader");
-        headerNames.add("otherHeader");
-        headerNames.add("secureHeaderToRemove");
-        when(request.getHeaderNames()).thenReturn(Collections.enumeration(headerNames));
+        String[] headerNames = new String[] {"secureHeader","otherHeader", "secureHeaderToRemove"};
+        when(request.getHeaderNames()).thenReturn(Collections.enumeration(Arrays.asList(headerNames)));
         when(request.getHeader("secureHeader")).thenReturn("secret");
         when(request.getHeader("otherHeader")).thenReturn("otherValue");
         when(request.getHeader("secureHeaderToRemove")).thenReturn("secret2");
@@ -139,11 +136,9 @@ public class TestRollbarFilter {
         
         // then
         Map<String, String> actual = MDC.getCopyOfContextMap();
-        System.out.println(actual.toString());
         assertThat(actual.get("request.header.secureHeader"), is(equalTo("XXX")));
         assertThat(actual.get("request.header.otherHeader"), is(equalTo("otherValue")));
         assertFalse(actual.containsKey("request.header.secureHeaderToRemove"));
-        
     }
     
 }

--- a/src/test/java/com/tapstream/rollbar/TestRollbarFilter.java
+++ b/src/test/java/com/tapstream/rollbar/TestRollbarFilter.java
@@ -4,7 +4,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.equalToIgnoringCase;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.empty;
 import static org.junit.Assert.assertFalse;
 import static org.mockito.Matchers.argThat;
 import static org.mockito.Mockito.when;
@@ -84,7 +84,8 @@ public class TestRollbarFilter {
         when(request.getParameterNames()).thenReturn(params.keys());
         when(request.getParameter(paramName)).thenReturn(paramValue);
 
-        filter.insertIntoMDC(request);
+        Map<String, String> details = filter.collectDetails(request);
+        filter.putToMDC(details);
         
         Map<String, String> actual = MDC.getCopyOfContextMap();
         @SuppressWarnings("serial")
@@ -101,8 +102,8 @@ public class TestRollbarFilter {
         
         assertThat(actual, is(equalTo(expected)));
         
-        filter.clearMDC();
-        assertThat(MDC.getCopyOfContextMap(), is(nullValue()));
+        filter.clearMDC(details);
+        assertThat(MDC.getCopyOfContextMap().keySet(), is(empty()));
     }
     
     @Test
@@ -132,7 +133,8 @@ public class TestRollbarFilter {
         
         // when
         RollbarFilter filter = new RollbarFilter(headerSanitizer);
-        filter.insertIntoMDC(request);
+        Map<String, String> details = filter.collectDetails(request);
+        filter.putToMDC(details);
         
         // then
         Map<String, String> actual = MDC.getCopyOfContextMap();


### PR DESCRIPTION
This adds a way to sanitise http headers before saving them for rollbar. Basically RollbarFilter uses HeaderSanitizer to filter headers when storing them in MDC.
HeaderSanitizer implementation is project-specific and is not provided, except the default NoOpHeaderSanitizer which does nothing.