### PR TITLE
Support StructuredArguments

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -139,6 +139,12 @@
 		    <version>1.6</version>
 		</dependency>
 		<dependency>
+			<groupId>net.logstash.logback</groupId>
+			<artifactId>logstash-logback-encoder</artifactId>
+			<version>5.0</version>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
 			<groupId>javax.servlet</groupId>
 			<artifactId>javax.servlet-api</artifactId>
 			<version>3.1.0</version>

--- a/src/main/java/com/tapstream/rollbar/Message.java
+++ b/src/main/java/com/tapstream/rollbar/Message.java
@@ -1,0 +1,25 @@
+package com.tapstream.rollbar;
+
+import org.json.JSONObject;
+
+public class Message {
+    private final String text;
+    private final JSONObject additionalArguments;
+
+    public Message(String text) {
+        this(text, new JSONObject());
+    }
+
+    public Message(String text, JSONObject additionalArguments) {
+        this.text = text;
+        this.additionalArguments = additionalArguments;
+    }
+
+    public String getText() {
+        return text;
+    }
+
+    public JSONObject getAdditionalArguments() {
+        return additionalArguments;
+    }
+}

--- a/src/main/java/com/tapstream/rollbar/MessageProvider.java
+++ b/src/main/java/com/tapstream/rollbar/MessageProvider.java
@@ -1,0 +1,14 @@
+package com.tapstream.rollbar;
+
+import ch.qos.logback.classic.spi.ILoggingEvent;
+
+/**
+ * Extract Message from LoggingEvent.
+ * <p>
+ * Message contains text and (optionally) extra arguments already serialized to JSONObject. This interface allows
+ * to chose implementation based on what types are on the classpath and in the effect to support StructuredArguments
+ * from logback-logstash-encoder.
+ */
+public interface MessageProvider {
+    Message get(ILoggingEvent event);
+}

--- a/src/main/java/com/tapstream/rollbar/messageprovider/DefaultMessageProvider.java
+++ b/src/main/java/com/tapstream/rollbar/messageprovider/DefaultMessageProvider.java
@@ -1,0 +1,12 @@
+package com.tapstream.rollbar.messageprovider;
+
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import com.tapstream.rollbar.Message;
+import com.tapstream.rollbar.MessageProvider;
+
+public class DefaultMessageProvider implements MessageProvider {
+    @Override
+    public Message get(ILoggingEvent event) {
+        return new Message(event.getFormattedMessage());
+    }
+}

--- a/src/main/java/com/tapstream/rollbar/messageprovider/LogstashMessageProvider.java
+++ b/src/main/java/com/tapstream/rollbar/messageprovider/LogstashMessageProvider.java
@@ -1,0 +1,93 @@
+package com.tapstream.rollbar.messageprovider;
+
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.tapstream.rollbar.Message;
+import com.tapstream.rollbar.MessageProvider;
+import net.logstash.logback.argument.StructuredArgument;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.util.Iterator;
+
+/**
+ * Extracts unformatted message and structured arguments from LoggingEvent.
+ */
+public class LogstashMessageProvider implements MessageProvider {
+    private final ObjectMapper mapper = new ObjectMapper();
+    private final JsonFactory factory = new JsonFactory();
+
+    private final DefaultMessageProvider defaultProvider = new DefaultMessageProvider();
+
+    @Override
+    public Message get(ILoggingEvent event) {
+        if (!hasStructuredArgs(event)) {
+            return defaultProvider.get(event);
+        }
+
+        try {
+            JSONObject jsonArgs = argumentsToJsonObject(event.getArgumentArray());
+
+            return new Message(event.getMessage(), jsonArgs);
+        } catch (IOException | JSONException | RuntimeException e) {
+            JSONObject o = new JSONObject();
+            try {
+                o.put("error", e.toString());
+            } catch (JSONException ignore) {
+            }
+            return new Message(event.getMessage(), o);
+        }
+    }
+
+    private JSONObject argumentsToJsonObject(Object[] arguments) throws IOException, JSONException {
+        JSONObject jsonArgs = new JSONObject();
+        for (int idx = 0; idx < arguments.length; idx++) {
+            Object arg = arguments[idx];
+            if (arg instanceof StructuredArgument) {
+                JSONObject obj = toJsonObject((StructuredArgument) arg);
+                merge(jsonArgs, obj);
+            } else if (arg != null && arg instanceof Number) {
+                jsonArgs.put("arg" + idx, arg);
+            } else if (arg != null) {
+                jsonArgs.put("arg" + idx, arg.toString());
+            } else {
+                jsonArgs.put("arg" + idx, null);
+            }
+        }
+        return jsonArgs;
+    }
+
+    private boolean hasStructuredArgs(ILoggingEvent event) {
+        if (event.getArgumentArray() == null) {
+            return false;
+        }
+        for (Object arg : event.getArgumentArray()) {
+            if (arg instanceof StructuredArgument) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private void merge(JSONObject jsonArgs, JSONObject obj) throws JSONException {
+        for (Iterator it = obj.keys(); it.hasNext(); ) {
+            String key = (String) it.next();
+            jsonArgs.put(key, obj.get(key));
+        }
+    }
+
+    private JSONObject toJsonObject(StructuredArgument arg) throws IOException, JSONException {
+        StringWriter w = new StringWriter();
+        JsonGenerator gen = factory.createGenerator(w);
+        gen.setCodec(mapper);
+        gen.writeStartObject();
+        arg.writeTo(gen);
+        gen.writeEndObject();
+        gen.flush();
+        return new JSONObject(w.toString());
+    }
+}

--- a/src/test/java/com/tapstream/rollbar/TestNotifyBuilder.java
+++ b/src/test/java/com/tapstream/rollbar/TestNotifyBuilder.java
@@ -32,7 +32,7 @@ public class TestNotifyBuilder {
         when(serverDataProvider.getServerData()).thenReturn(new JSONObject("{host:abc, ip:10.20.30.40}"));
 
         NotifyBuilder builder = new NotifyBuilder("key", "env", serverDataProvider, notifierDataProvider, null);
-        JSONObject result = builder.build("lvl", "msg", null, new HashMap<String, String>(), "logger.name");
+        JSONObject result = builder.build("lvl", new Message("msg"), null, new HashMap<String, String>(), "logger.name");
 
         JSONObject data = result.getJSONObject("data");
         assertNotNull(data.getJSONObject("server"));
@@ -46,7 +46,7 @@ public class TestNotifyBuilder {
         when(notifierDataProvider.getNotifierData()).thenReturn(new JSONObject("{name:abc, version:'12.0'}"));
 
         NotifyBuilder builder = new NotifyBuilder("key", "env", serverDataProvider, notifierDataProvider, null);
-        JSONObject result = builder.build("lvl", "msg", null, new HashMap<String, String>(), "logger.name");
+        JSONObject result = builder.build("lvl", new Message("msg"), null, new HashMap<String, String>(), "logger.name");
 
         JSONObject data = result.getJSONObject("data");
         assertNotNull(data.getJSONObject("notifier"));
@@ -63,7 +63,7 @@ public class TestNotifyBuilder {
         ctx.put("person.username", "john");
         ctx.put("person.email", "john@example.org");
 
-        JSONObject result = builder.build("lvl", "msg", null, ctx, "logger.name");
+        JSONObject result = builder.build("lvl", new Message("msg"), null, ctx, "logger.name");
 
         assertEquals(true, result.getJSONObject("data").has("person"));
         JSONObject person = result.getJSONObject("data").getJSONObject("person");
@@ -77,7 +77,7 @@ public class TestNotifyBuilder {
         NotifyBuilder builder = new NotifyBuilder("key", "env", serverDataProvider, notifierDataProvider, null);
         Map<String, String> ctx = new HashMap<>();
 
-        JSONObject result = builder.build("lvl", "msg", null, ctx, "logger.name");
+        JSONObject result = builder.build("lvl", new Message("msg"), null, ctx, "logger.name");
 
         assertFalse(result.getJSONObject("data").has("person"));
     }
@@ -88,7 +88,7 @@ public class TestNotifyBuilder {
         Map<String, String> ctx = new HashMap<>();
         ctx.put("request.method", "PUT");
         ctx.put("request.param.param1", "param1val");
-        JSONObject result = builder.build("lvl", "msg", null, ctx, "logger.name");
+        JSONObject result = builder.build("lvl", new Message("msg"), null, ctx, "logger.name");
 
         JSONObject req = result.getJSONObject("data").getJSONObject("request");
         assertEquals("PUT", req.get("method"));
@@ -101,7 +101,7 @@ public class TestNotifyBuilder {
         Map<String, String> ctx = new HashMap<>();
         ctx.put("request.method", "PATCH");
         ctx.put("request.param.param1", "param1val");
-        JSONObject result = builder.build("lvl", "msg", null, ctx, "logger.name");
+        JSONObject result = builder.build("lvl", new Message("msg"), null, ctx, "logger.name");
 
         JSONObject req = result.getJSONObject("data").getJSONObject("request");
         assertEquals("PATCH", req.get("method"));
@@ -114,7 +114,7 @@ public class TestNotifyBuilder {
         Map<String, String> ctx = new HashMap<>();
         ctx.put("request.method", "DELETE");
         ctx.put("request.param.param1", "param1val");
-        JSONObject result = builder.build("lvl", "msg", null, ctx, "logger.name");
+        JSONObject result = builder.build("lvl", new Message("msg"), null, ctx, "logger.name");
 
         JSONObject req = result.getJSONObject("data").getJSONObject("request");
         assertEquals("DELETE", req.get("method"));
@@ -130,7 +130,7 @@ public class TestNotifyBuilder {
             }
         });
         
-        JSONObject result = builder.build("lvl", "msg", new RuntimeException(), new HashMap<String,String>(), "x");
+        JSONObject result = builder.build("lvl", new Message("msg"), new RuntimeException(), new HashMap<String,String>(), "x");
         
         assertNotNull(result.getJSONObject("data").get("fingerprint"));
     }
@@ -139,7 +139,7 @@ public class TestNotifyBuilder {
     public void doesNotSetFingerprintWhenFingerprinterMissing() throws Exception{
         NotifyBuilder builder = new NotifyBuilder("key", "env", serverDataProvider, notifierDataProvider, null);
         
-        JSONObject result = builder.build("lvl", "msg", new RuntimeException(), new HashMap<String,String>(), "x");
+        JSONObject result = builder.build("lvl", new Message("msg"), new RuntimeException(), new HashMap<String,String>(), "x");
         
         assertFalse(result.getJSONObject("data").has("fingerprint"));
         

--- a/src/test/java/com/tapstream/rollbar/TestRollbarAppender.java
+++ b/src/test/java/com/tapstream/rollbar/TestRollbarAppender.java
@@ -1,7 +1,7 @@
 package com.tapstream.rollbar;
 
-import static org.junit.Assert.*;
-
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.LoggerContext;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -10,31 +10,36 @@ import org.junit.Before;
 import org.junit.Test;
 import org.slf4j.LoggerFactory;
 
-import com.tapstream.rollbar.HttpRequest;
-import com.tapstream.rollbar.RollbarAppender;
+import java.util.HashMap;
+import java.util.Map;
 
-import ch.qos.logback.classic.Logger;
-import ch.qos.logback.classic.LoggerContext;
+import static net.logstash.logback.argument.StructuredArguments.entries;
+import static net.logstash.logback.argument.StructuredArguments.kv;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 public class TestRollbarAppender {
-    
+
     String apiKey = "api key";
     String endpoint = "http://rollbar.endpoint/";
     String env = "test";
-    
+
     Logger rootLogger;
     LoggerContext loggerContext;
     RollbarAppender appender;
     MockHttpRequester httpRequester;
-    
+
     @Before
     public void setup() {
         httpRequester = new MockHttpRequester();
-        
+
         rootLogger = (Logger) LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
         loggerContext = rootLogger.getLoggerContext();
         loggerContext.reset();
-                
+
         appender = new RollbarAppender();
         appender.setUrl(endpoint);
         appender.setApiKey(apiKey);
@@ -44,67 +49,67 @@ public class TestRollbarAppender {
         appender.setContext(loggerContext);
         appender.start();
         assertTrue(appender.isStarted());
-        rootLogger.addAppender(appender);        
+        rootLogger.addAppender(appender);
     }
-    
+
     @After
-    public void teardown(){
-        
+    public void teardown() {
+
     }
-    
-    private void checkCommonRequestFields(HttpRequest request){
+
+    private void checkCommonRequestFields(HttpRequest request) {
         assertNotNull(request);
         assertEquals("POST", request.getMethod());
         assertEquals(endpoint, request.getUrl().toString());
     }
-    
+
     @Test
     public void testMessage() throws Exception {
         String testMsg = "test";
         rootLogger.info(testMsg);
-        HttpRequest request  = httpRequester.getRequest();
+        HttpRequest request = httpRequester.getRequest();
         checkCommonRequestFields(request);
-        
+
         JSONObject root = new JSONObject(new String(request.getBody()));
         assertEquals(apiKey, root.get("access_token"));
-        
+
         JSONObject data = root.getJSONObject("data");
         assertEquals(env, data.get("environment"));
         assertEquals("info", data.get("level"));
         assertEquals("java", data.get("platform"));
         assertEquals("java", data.get("language"));
         assertEquals("java", data.get("framework"));
-        
+
         JSONObject body = data.getJSONObject("body");
         assertEquals(testMsg, body.getJSONObject("message").get("body"));
     }
-    
+
     @Test
     public void testMessageSendError() throws Exception {
         String testMsg = "test";
         httpRequester.setResponseCode(500);
         rootLogger.info(testMsg);
     }
-    
+
     @Test
     public void testThrowable() throws Exception {
         String testMsg = "test error";
         String testThrowableMsg = "test throwable";
         Throwable throwable = new Exception(testThrowableMsg);
         rootLogger.error(testMsg, throwable);
-        HttpRequest request  = httpRequester.getRequest();
+        HttpRequest request = httpRequester.getRequest();
         checkCommonRequestFields(request);
-        
+
         JSONObject root = new JSONObject(new String(request.getBody()));
         assertEquals(apiKey, root.get("access_token"));
-        
+
         JSONObject data = root.getJSONObject("data");
         assertEquals(env, data.get("environment"));
         assertEquals("error", data.get("level"));
         assertEquals("java", data.get("platform"));
         assertEquals("java", data.get("language"));
         assertEquals("java", data.get("framework"));
-    
+
         JSONObject body = data.getJSONObject("body");
         JSONArray traceChain = body.getJSONArray("trace_chain");
         JSONObject firstTrace = traceChain.getJSONObject(0);
@@ -116,11 +121,51 @@ public class TestRollbarAppender {
         JSONObject firstException = firstTrace.getJSONObject("exception");
         assertEquals(testThrowableMsg, firstException.get("message"));
         assertEquals("java.lang.Exception", firstException.get("class"));
-        
+
         JSONObject custom = data.getJSONObject("custom");
         assertEquals(testMsg, custom.get("log"));
     }
-    
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testStructuredArgumentsWithKeyValue() throws JSONException {
+        rootLogger.error("some message", kv("k", "v"), kv("other-k", "other-v"));
+
+        HttpRequest request = httpRequester.getRequest();
+        checkCommonRequestFields(request);
+
+        JSONObject root = new JSONObject(new String(request.getBody()));
+
+        JSONObject data = (JSONObject) root.get("data");
+        JSONObject custom = (JSONObject) data.get("custom");
+        JSONObject args = (JSONObject) custom.get("args");
+
+        assertThat(args.keys()).containsOnly("k", "other-k");
+        assertThat(args.get("k")).isEqualTo("v");
+        assertThat(args.get("other-k")).isEqualTo("other-v");
+    }
+
+    @Test
+    public void testStructuredArgumentsWithEntries() throws JSONException {
+        Map<String, Object> inner = new HashMap<>();
+        inner.put("inner", "innervalue");
+        Map<String, Object> outer = new HashMap<>();
+        outer.put("outer", inner);
+
+        rootLogger.error("some message", entries(outer));
+
+        HttpRequest request = httpRequester.getRequest();
+        checkCommonRequestFields(request);
+
+        JSONObject root = new JSONObject(new String(request.getBody()));
+
+        JSONObject data = (JSONObject) root.get("data");
+        JSONObject custom = (JSONObject) data.get("custom");
+        JSONObject args = (JSONObject) custom.get("args");
+
+        assertEquals("{\"outer\":{\"inner\":\"innervalue\"}}", args.toString());
+    }
+
     @Test
     public void contextContainsRootLoggerName() throws JSONException {
         rootLogger.info("test message");
@@ -130,7 +175,7 @@ public class TestRollbarAppender {
 
         assertEquals(root.getJSONObject("data").get("context"), Logger.ROOT_LOGGER_NAME);
     }
-    
+
     @Test
     public void contextContainsSubLoggerName() throws JSONException {
         Logger subLogger = (Logger) LoggerFactory.getLogger("some.logger");

--- a/src/test/java/com/tapstream/rollbar/messageprovider/LogstashMessageProviderTest.java
+++ b/src/test/java/com/tapstream/rollbar/messageprovider/LogstashMessageProviderTest.java
@@ -1,0 +1,131 @@
+package com.tapstream.rollbar.messageprovider;
+
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.UnsynchronizedAppenderBase;
+import com.tapstream.rollbar.Message;
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static net.logstash.logback.argument.StructuredArguments.array;
+import static net.logstash.logback.argument.StructuredArguments.entries;
+import static net.logstash.logback.argument.StructuredArguments.kv;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertTrue;
+
+public class LogstashMessageProviderTest {
+    LogstashMessageProvider p = new LogstashMessageProvider();
+    private Logger log;
+    private TestAppender appender;
+
+    @Before
+    public void setup() {
+        log = (Logger) LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
+        LoggerContext loggerContext = log.getLoggerContext();
+        loggerContext.reset();
+
+        appender = new TestAppender();
+        appender.setContext(loggerContext);
+        appender.start();
+        assertTrue(appender.isStarted());
+        log.addAppender(appender);
+    }
+
+    @Test
+    public void mergesKeyValuesIntoSingleObject() throws JSONException {
+        log.info("message {}", kv("key", "value"), kv("key2", "value2"), kv("key2", "different"));
+
+        Message message = p.get(appender.event);
+
+        JSONObject args = message.getAdditionalArguments();
+        assertThat(args.length()).isEqualTo(2);
+        assertThat(args.get("key")).isEqualTo("value");
+        assertThat(args.get("key2")).isIn("value2", "different");
+    }
+
+    @Test
+    public void supportsArrays() throws JSONException {
+        log.info("message {}", array("field", 1, 2));
+
+        Message message = p.get(appender.event);
+
+        JSONObject args = message.getAdditionalArguments();
+        assertThat(args.length()).isEqualTo(1);
+        assertThat(args.get("field")).isEqualTo(new JSONArray("[1,2]"));
+    }
+
+    @Test
+    public void supportsEntries() throws JSONException {
+        Map<String, Map<String, Integer>> map = new HashMap<>();
+        Map<String, Integer> b = new HashMap<>();
+        b.put("y", 2);
+        map.put("x", b);
+
+
+        log.info("message {}", entries(map));
+
+        Message message = p.get(appender.event);
+
+        JSONObject args = message.getAdditionalArguments();
+        JSONObject y = (JSONObject) args.get("x");
+        assertThat(y).isNotNull();
+        assertThat(y.get("y")).isEqualTo(2);
+    }
+
+    @Test
+    public void usesUnformattedMessageWithStructuredArguments() {
+        log.info("message {}", array("f", 1));
+
+        Message message = p.get(appender.event);
+
+        assertThat(message.getText()).isEqualTo("message {}");
+    }
+
+    @Test
+    public void usesFormattedMessageIfNoStructuredArgument() {
+        log.info("message {}", "xyz");
+
+        Message message = p.get(appender.event);
+
+        assertThat(message.getText()).isEqualTo("message xyz");
+    }
+
+    @Test
+    public void usesFormattedMessageIfNoArgument() {
+        log.info("message");
+
+        Message message = p.get(appender.event);
+
+        assertThat(message.getText()).isEqualTo("message");
+    }
+
+    @Test
+    public void exceptionIsNotIncluded() {
+        log.info("message {}", kv("k", "v"), new RuntimeException());
+
+        Message message = p.get(appender.event);
+
+        assertThat(message.getAdditionalArguments().length()).isEqualTo(1);
+        assertThat(message.getAdditionalArguments().has("k")).isTrue();
+    }
+
+    static class TestAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
+        private ILoggingEvent event;
+
+        @Override
+        protected void append(ILoggingEvent event) {
+            if (this.event != null) {
+                throw new IllegalStateException("already appended an event");
+            }
+            this.event = event;
+        }
+    }
+}


### PR DESCRIPTION
When StructuredArguments (from logback-logstash-encoder) were used they weren't being reported to rollbar properly because previously we were sending formatted message (and ignoring arguments). This change adds optional support for StructuredArguments - it will only be used if logback-logstash-encoder is on the classpath.

As a result logback-rollbar will send additional field data.custom.args with map containing the arguments.

E.g. log.warn("watch out!", keyValue("reason", "a bear"), keyValue("severity", "high"))

Will send:
```
"custom":{
  "args":{
    "reason":"a bear",
    "severity":"high"
  }
}
```

The conversion of event arguments to JSONObject is pretty inefficient and basically uses jackson serialization and then GSON deserialization, but there doesn't seem to be an obvious way to get values from StructuredArguments

- [ ] check how it looks on rollbar and maybe tweak the format